### PR TITLE
Set WORKDIR to /data

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,4 +2,6 @@ FROM node
 
 RUN npm install markdown-pdf
 
+WORKDIR /data
+
 ENTRYPOINT ["/node_modules/markdown-pdf/bin/markdown-pdf"]


### PR DESCRIPTION
Set workdir to the actual data directory so that relative references
inside the Markdown file (like graphics) don't break.